### PR TITLE
Fix mistake in url after adding rootdir to entry.path

### DIFF
--- a/src/nimibook/types.nim
+++ b/src/nimibook/types.nim
@@ -34,7 +34,7 @@ proc publish*(entry: Entry) =
     raise newException(IOError, "Error invalid file extension.")
 
 proc url*(e: Entry): string =
-  var path = changeFileExt(e.path, "html")
+  var path = changeFileExt(e.path, "html").tailDir()
   when defined(windows):
     path.replace('\\', '/')
   else:


### PR DESCRIPTION
This one was an oversight on my part, sorry :/ .

After adding ``rootdir``to ``entry.path`` it got added to the ``url()`` too... Therefore we need to take tailDir() on the url proc to generate correct URL.

This also points that github actions being green does not guarantee correct book generation. Maybe we could add a sanity check afterwards checking that the html files we link to are correct ?
