### PR TITLE
add toc.check to verify url generated from entry.path

### DIFF
--- a/src/nimibook.nim
+++ b/src/nimibook.nim
@@ -71,8 +71,14 @@ proc load*(path: string): Toc =
   let uri = normalizedPath(path)
   readFile(uri).fromJson(Toc)
 
+proc check*(toc: Toc) =
+  for entry in toc.entries:
+    entry.check()
+  echo "Check toc => OK"
+
 proc publish*(toc: Toc) =
   dump toc
   for entry in toc.entries:
     entry.publish()
   clean toc
+  check(toc)

--- a/src/nimibook/types.nim
+++ b/src/nimibook/types.nim
@@ -1,4 +1,4 @@
-import std/strutils
+import std/[strutils, strformat]
 import std/os
 
 type
@@ -40,3 +40,7 @@ proc url*(e: Entry): string =
   else:
     path
 
+proc check*(e: Entry) =
+  let entryurl = url(e)
+  if not fileExists("docs" / entryurl):
+    raise newException(IOError, fmt"Error finding {entryurl} : no such file or directory")


### PR DESCRIPTION
@pietroppeter This is my idea regarding the PR automated check we talked about in https://github.com/pietroppeter/nimibook/pull/13#issuecomment-849313200.

The ``docs`` part of the path is hardcoded, I'm not sure if that's acceptable or not 