### PR TITLE
return empty book if book.json not found

### DIFF
--- a/src/nimibook/books.nim
+++ b/src/nimibook/books.nim
@@ -118,6 +118,7 @@ proc load*(path: string): Book =
   if fileExists(uri):
     result = readFile(uri).fromJson(Book)
   else:
+    echo "Warning! No book.json was found!"
     result = Book()
 
 proc check*(book: Book) =

--- a/src/nimibook/books.nim
+++ b/src/nimibook/books.nim
@@ -115,7 +115,10 @@ proc clean*(book: Book) =
 
 proc load*(path: string): Book =
   let uri = normalizedPath(path)
-  readFile(uri).fromJson(Book)
+  if fileExists(uri):
+    result = readFile(uri).fromJson(Book)
+  else:
+    result = Book()
 
 proc check*(book: Book) =
   for entry in book.toc.entries:


### PR DESCRIPTION
Fixes https://github.com/pietroppeter/nimibook/issues/21

The reason I chose to explicitly return `Book()` is if we in the future make `Book` a `ref object` for some reason it won't give is `nil`.