### PR TITLE
Fix async and some other stuff

### DIFF
--- a/nimibook.nimble
+++ b/nimibook.nimble
@@ -10,7 +10,7 @@ srcDir        = "src"
 # Dependencies
 
 requires "nim >= 1.4.0"
-requires "nimib#head"
+requires "nimib >= 0.3.5"
 requires "jsony >= 1.0.3"
 requires "toml_serialization >= 0.2.0"
 

--- a/src/nimibook/builds.nim
+++ b/src/nimibook/builds.nim
@@ -17,7 +17,7 @@ proc buildNim*(entry: Entry, srcDir: string, nimOptions: seq[string]): Future[bo
   result = process.peekexitCode == 0
   if not result:
     # Process failed so we write a '.log'
-    let logPath = entry.path.changeFileExt("log")
+    let logPath = srcDir / entry.path.changeFileExt("log")
     discard tryRemoveFile(logPath)
     let fs = openFileStream(logPath, fmWrite)
     defer: fs.close()
@@ -68,6 +68,9 @@ proc build*(book: Book, nimOptions: seq[string] = @[]) =
   if len(buildErrors) > 0:
     echo "[nimibook.error] ", len(buildErrors), " build errors:"
     for err in buildErrors:
+      echo "\n#########################\n"
       echo "  ❌ ", err
+      let errorLog = readFile(book.srcDir / err.changeFileExt("log"))
+      echo errorLog
     quit(1)
   check book

--- a/src/nimibook/entries.nim
+++ b/src/nimibook/entries.nim
@@ -50,7 +50,7 @@ proc nextEntryUrl*(book: Book, i: int): string =
   var j = i + 1
   while j >= 0 and j < book.toc.entries.high and book.toc.entries[j].isDraft:
     inc j
-  if j >= 0 and j < book.toc.entries.high:
+  if j >= 0 and j <= book.toc.entries.high:
     result = book.toc.entries[j].url
 
 proc prevEntryUrl*(book: Book, i: int): string =


### PR DESCRIPTION
This PR fixes #59 and #57 (partially). 

The compile options `-d:nimibParallelBuild=true/false` and `-d:nimibMaxProcesses=n` are introduced to control the parallel build of documents and the maximum number of concurrent builds to run at the same time.