### PR TITLE
Use custom nested nimcache folder structure

### DIFF
--- a/book/cli.nim
+++ b/book/cli.nim
@@ -51,5 +51,12 @@ By default it builds up to a maximum of 10 source files in parallel.
 To change the default maximum to `n` you can set
 `-d:nimibMaxProcesses=n` when compiling `nbook`.
 
+To avoid file collisions of C/object files in nimcache for files with the same name,
+typically you have multiple `index.nim` files in separate folders for example, 
+each file will get its own nimcache folder. For example the file `tutorials/tut1.nim`
+will be assigned the nimcache folder `$nimcache/tutorials/tut1/` where `$nimcache` is the
+nimcache folder of the file were you run `nimibookCli`.
+Without this they would both try to use the same `index_r`/`index_d` folder in nimcache and mutate the same files.
+All of this is handled by nimiBook, so you don't have to worry about this.
 """
 nbSave

--- a/book/cli.nim
+++ b/book/cli.nim
@@ -53,8 +53,8 @@ To change the default maximum to `n` you can set
 
 To avoid file collisions of C/object files in nimcache for files with the same name,
 typically you have multiple `index.nim` files in separate folders for example, 
-each file will get its own nimcache folder. For example the file `tutorials/tut1.nim`
-will be assigned the nimcache folder `$nimcache/tutorials/tut1/` where `$nimcache` is the
+each file will get its own nimcache folder. For example the files `index.nim` and `tutorials/index.nim`
+will be assigned the nimcache folders `$nimcache/index/` and `$nimcache/tutorials/index/` where `$nimcache` is the
 nimcache folder of the file were you run `nimibookCli`.
 Without this they would both try to use the same `index_r`/`index_d` folder in nimcache and mutate the same files.
 All of this is handled by nimiBook, so you don't have to worry about this.

--- a/src/nimibook/builds.nim
+++ b/src/nimibook/builds.nim
@@ -1,4 +1,4 @@
-import std / [os, strutils, asyncdispatch, osproc, streams, sugar, strformat]
+import std / [os, strutils, asyncdispatch, osproc, streams, sugar]
 import std/compilesettings
 import nimibook / [types, commands, themes]
 import nimib
@@ -13,7 +13,7 @@ proc buildNim*(entry: Entry, srcDir: string, nimOptions: seq[string]): Future[bo
   createDir(cacheFolder)
   let
     cmd = "nim"
-    args = @["r", &"--nimcache:{cacheFolder}"] & nimOptions & @[srcDir / entry.path]
+    args = @["r", "--nimcache:" & cacheFolder] & nimOptions & @[srcDir / entry.path]
   # "-d:release", "-f", "--verbosity:0", "--hints:off"
   debugEcho "[Executing] ", cmd, " ", args.join(" ")
 

--- a/src/nimibook/builds.nim
+++ b/src/nimibook/builds.nim
@@ -8,7 +8,7 @@ const nimcacheFolder = querySetting(SingleValueSetting.nimcacheDir)
 var numberBuildsRunning = 0
 
 proc buildNim*(entry: Entry, srcDir: string, nimOptions: seq[string]): Future[bool] {.async.} =
-  let cacheFolder = nimcacheFolder / splitPath(entry.path).head
+  let cacheFolder = nimcacheFolder / splitFile(entry.path).dir & "_" & splitFile(entry.path).name
   createDir(cacheFolder)
   let
     cmd = "nim"

--- a/src/nimibook/builds.nim
+++ b/src/nimibook/builds.nim
@@ -8,7 +8,8 @@ const nimcacheFolder = querySetting(SingleValueSetting.nimcacheDir)
 var numberBuildsRunning = 0
 
 proc buildNim*(entry: Entry, srcDir: string, nimOptions: seq[string]): Future[bool] {.async.} =
-  let cacheFolder = nimcacheFolder / splitFile(entry.path).dir / splitFile(entry.path).name
+  let splitEntry = splitFile(entry.path)
+  let cacheFolder = nimcacheFolder / splitEntry.dir / splitEntry.name
   createDir(cacheFolder)
   let
     cmd = "nim"

--- a/src/nimibook/builds.nim
+++ b/src/nimibook/builds.nim
@@ -9,6 +9,10 @@ var numberBuildsRunning = 0
 
 proc buildNim*(entry: Entry, srcDir: string, nimOptions: seq[string]): Future[bool] {.async.} =
   let splitEntry = splitFile(entry.path)
+  # To avoid collisions of the intermediate C/object files for files with the same name,
+  # e.g. index.nim and some_folder/index.nim, we make a separate nimcache folder for each file.
+  # This way all files are isolated from each other. In the example the two folders would be
+  # nimcache/index/ and nimcache/some_folder/index/
   let cacheFolder = nimcacheFolder / splitEntry.dir / splitEntry.name
   createDir(cacheFolder)
   let

--- a/src/nimibook/builds.nim
+++ b/src/nimibook/builds.nim
@@ -1,13 +1,18 @@
-import std / [os, strutils, asyncdispatch, osproc, streams, sugar]
+import std / [os, strutils, asyncdispatch, osproc, streams, sugar, strformat]
+import std/compilesettings
 import nimibook / [types, commands, themes]
 import nimib
+
+const nimcacheFolder = querySetting(SingleValueSetting.nimcacheDir)
 
 var numberBuildsRunning = 0
 
 proc buildNim*(entry: Entry, srcDir: string, nimOptions: seq[string]): Future[bool] {.async.} =
+  let cacheFolder = nimcacheFolder / splitPath(entry.path).head
+  createDir(cacheFolder)
   let
     cmd = "nim"
-    args = @["r"] & nimOptions & @[srcDir / entry.path]
+    args = @["r", &"--nimcache:{cacheFolder}"] & nimOptions & @[srcDir / entry.path]
   # "-d:release", "-f", "--verbosity:0", "--hints:off"
   debugEcho "[Executing] ", cmd, " ", args.join(" ")
 

--- a/src/nimibook/builds.nim
+++ b/src/nimibook/builds.nim
@@ -8,7 +8,7 @@ const nimcacheFolder = querySetting(SingleValueSetting.nimcacheDir)
 var numberBuildsRunning = 0
 
 proc buildNim*(entry: Entry, srcDir: string, nimOptions: seq[string]): Future[bool] {.async.} =
-  let cacheFolder = nimcacheFolder / splitFile(entry.path).dir & "_" & splitFile(entry.path).name
+  let cacheFolder = nimcacheFolder / splitFile(entry.path).dir / splitFile(entry.path).name
   createDir(cacheFolder)
   let
     cmd = "nim"


### PR DESCRIPTION
fixes #81

This PR changes the nimcache folder such that `.nim` files in different folders get different nimcache folder. 

I'm not entirely done, but I want to see what the CI says.