### PR TITLE
#80 add license page to nimibook

### DIFF
--- a/book/licenses.nim
+++ b/book/licenses.nim
@@ -1,0 +1,22 @@
+import nimib, nimibook
+
+nbInit(theme = useNimibook)
+nbText: """## Licenses
+Nimibook consists of multiple different parts, some of which have their own licenses.
+This is a compiled list of all licenses including those of assets used:
+  
+- Fonts:
+  - Open Sans (Apache License 2.0)
+  - Source Code Pro (SIL Open Font License, Version 1.1)
+  - FontAwesome:
+    - Fonts (SIL OFL 1.1)
+    - CSS (MIT)
+- Code
+  - clipboard.js (MIT)
+  - Highlight.js (BSD-3-Clause)
+  - book.js (MPL-2.0)
+  - KaTeX (MIT)
+- Themes (MPL-2.0)
+"""
+
+nbSave

--- a/nbook.nim
+++ b/nbook.nim
@@ -6,10 +6,10 @@ var book = initBookWithToc:
   entry("Table of Contents", "toc")
   entry("Configuration", "configuration")
   entry("Commands", "cli")
+  entry("Licenses", "licenses")
   section("Example toc structure", "tocexample/index.md"):
     section("Nested section", "nested.md"):
       entry("Entry in nested section", "nested_entry.md")
     entry("Back to parent section", "back_to_parent.md")
     draft("Draft chapter")
-
 nimibookCli(book)


### PR DESCRIPTION
As per #80 this adds the suggested page from the nimibook.

Note: I did basically 0 research for this. I read the issue and copy pasted the list from can.l + added KaTeX since it was mentioned during the issue.

If anything else needs adding, please say so.

The majority of the work here was done by Can.L either way ^^